### PR TITLE
apply some dockerfile best-practices for layering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,37 +14,29 @@ ARG ACTIVATE_ALL_STABLE_EXTENTIONS=1
 ARG ACTIVATE_ALL_COMMUNITY_EXTENTIONS=1
 
 #Install extra fonts to use with sld font markers
-RUN apt-get -y update; apt-get install -y fonts-cantarell lmodern ttf-aenigma ttf-georgewilliams ttf-bitstream-vera \
-    ttf-sjfonts tv-fonts build-essential libapr1-dev libssl-dev  gdal-bin libgdal-java wget zip curl xsltproc certbot \
-    certbot cabextract build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev \ 
-    libreadline-dev libffi-dev libbz2-dev
-
-RUN apt purge -y python2.7-minimal python2 python2.7
-
-RUN apt purge -y python3.7-minimal python3 python3.7
-
-RUN apt autoremove -y
-
+ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /tmp
-
-RUN wget https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz
-
-RUN tar -xf Python-3.9.2.tgz
-
-WORKDIR /tmp/Python-3.9.2
-
-RUN ./configure --enable-optimizations && make -j 8 && make altinstall
-
-RUN ln -s /usr/local/bin/python3.9 /usr/bin/python3
-
-WORKDIR /
-
-RUN wget http://ftp.br.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.6_all.deb && \
-    dpkg -i ttf-mscorefonts-installer_3.6_all.deb && rm ttf-mscorefonts-installer_3.6_all.deb
-
-RUN set -e \
-    export DEBIAN_FRONTEND=noninteractive \
-    dpkg-divert --local --rename --add /sbin/initctl \
+RUN apt-get -y update \
+    && apt-get install -y fonts-cantarell lmodern ttf-aenigma ttf-georgewilliams ttf-bitstream-vera \
+        ttf-sjfonts tv-fonts build-essential libapr1-dev libssl-dev  gdal-bin libgdal-java wget zip curl xsltproc certbot \
+        certbot cabextract build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev \
+        libreadline-dev libffi-dev libbz2-dev \
+    && apt purge -y python2.7-minimal python2 python2.7 \
+    && apt purge -y python3.7-minimal python3 python3.7 \
+    && apt autoremove -y \
+    # Install Python3.9
+    && wget https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz \
+    && tar -xf Python-3.9.2.tgz \
+    && cd /tmp/Python-3.9.2 \
+    && ./configure --enable-optimizations && make -j 8 && make altinstall \
+    && ln -s /usr/local/bin/python3.9 /usr/bin/python3 \
+    && rm -rf Python-3.9.2.tgz Python-3.9.2 \
+    && cd /tmp \
+    # MS Fonts
+    && wget http://ftp.br.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.6_all.deb \
+    && dpkg -i ttf-mscorefonts-installer_3.6_all.deb && rm ttf-mscorefonts-installer_3.6_all.deb \
+    # From original image
+    && dpkg-divert --local --rename --add /sbin/initctl \
     && (echo "Yes, do as I say!" | apt-get remove --force-yes login) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Best practice is to group `apt` commands and then do that `apt clean` and `rm -rf /var/lib/apt/lists/*` at the end. It keeps the layers smaller.